### PR TITLE
Read bump type from env

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,16 @@ module.exports = function(opts) {
 
   function modifyContents(file, cb) {
 
+    if(!opts.type){
+      var type = ['major', 'minor', 'patch'].filter(function(type){
+        return gutil.env[type];
+      });
+
+      if(type.length){
+        opts.type = type[0];
+      }
+    }
+
     if(file.isNull()) return cb(null, file);
     if(file.isStream()) return cb(new Error('gulp-bump: streams not supported'));
 


### PR DESCRIPTION
I think, it's very useful feature. The user can bump specific version from command line. For example:

```
gulp bump --patch
```

Maybe this PR needs tests, but I have no idea how it should look like, sorry.
