### PR TITLE
Fix broken link to NPM version CLI docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Usage
 
-If you are just requiring a bump for npm, consider using [npm version](https://npmjs.org/doc/cli/npm-version.html)
+If you are just requiring a bump for npm, consider using [npm version](https://docs.npmjs.com/cli/version)
 
 #### Install
 


### PR DESCRIPTION
I originally noticed that the link to `npm version` on the [npm page](https://www.npmjs.com/package/gulp-bump) was broken so came here to fix it. That said,the link in the GitHub repo is not broken. *That further said* the link in the GItHub repo redirects to the link in this pull request.

I guess the overall issue here is that at some point the `README.md` file got out of sync between GitHub and npm.

![404](https://cloud.githubusercontent.com/assets/174864/5931365/f3d50e04-a66a-11e4-9eb3-d18f56b0c908.png)

