### PR TITLE
Update plugin-error@1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "./index.js",
   "dependencies": {
     "bump-regex": "^3.1.1",
-    "plugin-error": "^0.1.2",
+    "plugin-error": "^1.0.1",
     "plugin-log": "^0.1.0",
     "semver": "^5.3.0",
     "through2": "^2.0.1"


### PR DESCRIPTION
Small update that can prune plugin-error@0.1.2 in the dependencies 😅 Tests are passing. The update should be pretty safe https://github.com/gulpjs/plugin-error/releases

Same as my PR for https://github.com/stevelacy/gulp-git 😛 